### PR TITLE
chore: filter out the classes that have invalid class name, e.g. primary::SchemaMigration

### DIFF
--- a/lib/adapters/wallaby/active_record/model_finder.rb
+++ b/lib/adapters/wallaby/active_record/model_finder.rb
@@ -15,17 +15,28 @@ module Wallaby
           defined?(::ApplicationRecord) && model_class == ::ApplicationRecord ||
             model_class.abstract_class? ||
             anonymous?(model_class) ||
-            model_class.name.index('HABTM')
+            model_class.name.index('HABTM') ||
+            invalid_class_name?(model_class)
         end.sort_by(&:to_s)
       end
 
       protected
 
+      # @param model_class [Class]
       # @see Wallaby::ModuleUtils.anonymous_class?
       def anonymous?(model_class)
         ModuleUtils.anonymous_class?(model_class).tap do |result|
           Logger.warn "Anonymous class is detected for table #{model_class.try :table_name}" if result
         end
+      end
+
+      # To exclude classes that have invalid class name, e.g. **primary::SchemaMigration** from Rails test
+      # @param model_class [Class]
+      def invalid_class_name?(model_class)
+        model_class.name.constantize
+        false
+      rescue NameError
+        true
       end
     end
   end

--- a/spec/adapters/wallaby/active_record/model_finder_spec.rb
+++ b/spec/adapters/wallaby/active_record/model_finder_spec.rb
@@ -7,29 +7,29 @@ describe Wallaby::ActiveRecord::ModelFinder do
       stub_const 'Airline', (Class.new { def self.abstract_class?; false; end })
       stub_const 'Airplane', (Class.new { def self.abstract_class?; false; end })
 
-      allow(ActiveRecord::Base).to receive(:descendants).and_return [Airport, Airplane, Airline]
+      expect(ActiveRecord::Base).to receive(:descendants).and_return [Airport, Airplane, Airline]
       expect(subject.all).to eq [Airline, Airplane, Airport]
     end
 
-    context 'when there is abstract class' do
+    context 'when it is an abstract class' do
       it 'filters out abstract class' do
         stub_const 'AbstractAirport', (Class.new { def self.abstract_class?; true; end })
 
-        allow(ActiveRecord::Base).to receive(:descendants).and_return [AbstractAirport]
+        expect(ActiveRecord::Base).to receive(:descendants).and_return [AbstractAirport]
         expect(subject.all).to be_blank
       end
     end
 
-    context 'when there is HABTM class' do
+    context 'when it is an HABTM class' do
       it 'filters out HABTM class' do
         stub_const 'Airplane::HABTM_Airports', (Class.new { def self.abstract_class?; false; end })
 
-        allow(ActiveRecord::Base).to receive(:descendants).and_return [Airplane::HABTM_Airports]
+        expect(ActiveRecord::Base).to receive(:descendants).and_return [Airplane::HABTM_Airports]
         expect(subject.all).to be_blank
       end
     end
 
-    context 'when there is anonymous class' do
+    context 'when it is an anonymous class' do
       it 'filters out anonymous class' do
         anonymous_class = Class.new do
           def self.abstract_class?
@@ -37,7 +37,23 @@ describe Wallaby::ActiveRecord::ModelFinder do
           end
         end
 
-        allow(ActiveRecord::Base).to receive(:descendants).and_return [anonymous_class]
+        expect(ActiveRecord::Base).to receive(:descendants).and_return [anonymous_class]
+        expect(subject.all).to be_blank
+      end
+    end
+
+    context 'when it is an invalid class name' do
+      it 'filters out invalid class name' do
+        stub_const 'InvalidClassName', (Class.new do
+          def self.abstract_class?
+            false
+          end
+          def self.name
+            'primary::SchemaMigration'
+          end
+        end)
+
+        expect(ActiveRecord::Base).to receive(:descendants).and_return [InvalidClassName]
         expect(subject.all).to be_blank
       end
     end

--- a/spec/adapters/wallaby/active_record/model_finder_spec.rb
+++ b/spec/adapters/wallaby/active_record/model_finder_spec.rb
@@ -48,6 +48,7 @@ describe Wallaby::ActiveRecord::ModelFinder do
           def self.abstract_class?
             false
           end
+
           def self.name
             'primary::SchemaMigration'
           end


### PR DESCRIPTION
### Summary

see https://github.com/wallaby-rails/wallaby/issues/186