### PR TITLE
chore: add GITHUB_REF_NAME as well

### DIFF
--- a/gemfiles/Gemfile.rails-5.2
+++ b/gemfiles/Gemfile.rails-5.2
@@ -13,7 +13,7 @@ gemspec path: '../'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 gem 'rails', '~> 5.2.0'
-gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF']
+gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF'] || ENV['GITHUB_REF_NAME']
 gem 'wallaby-cop', git: 'https://github.com/wallaby-rails/wallaby-cop.git', branch: 'main'
 
 gem 'cancancan'

--- a/gemfiles/Gemfile.rails-6.0
+++ b/gemfiles/Gemfile.rails-6.0
@@ -13,7 +13,7 @@ gemspec path: '../'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 gem 'rails', '~> 6.0.0'
-gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF']
+gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF'] || ENV['GITHUB_REF_NAME']
 gem 'wallaby-cop', git: 'https://github.com/wallaby-rails/wallaby-cop.git', branch: 'main'
 
 gem 'cancancan'

--- a/gemfiles/Gemfile.rails-6.1
+++ b/gemfiles/Gemfile.rails-6.1
@@ -13,7 +13,7 @@ gemspec path: '../'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 gem 'rails', '~> 6.1.0'
-gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF']
+gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF'] || ENV['GITHUB_REF_NAME']
 gem 'wallaby-cop', git: 'https://github.com/wallaby-rails/wallaby-cop.git', branch: 'main'
 
 gem 'cancancan'

--- a/gemfiles/Gemfile.rails-7.0
+++ b/gemfiles/Gemfile.rails-7.0
@@ -13,7 +13,7 @@ gemspec path: '../'
 # To use a debugger
 # gem 'byebug', group: [:development, :test]
 gem 'rails', '~> 7.0.0'
-gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF']
+gem 'wallaby-core', git: 'https://github.com/wallaby-rails/wallaby-core.git', branch: ENV['GITHUB_BASE_REF'] || ENV['GITHUB_REF_NAME']
 gem 'wallaby-cop', git: 'https://github.com/wallaby-rails/wallaby-cop.git', branch: 'main'
 
 gem 'cancancan'


### PR DESCRIPTION
### Summary

add GITHUB_REF_NAME to the gemfiles so that when it's the branch build, the branch name can be picked up.